### PR TITLE
Fix data race between AddModuleLevel and GetLevel

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -23,7 +23,9 @@ func SetBackend(backends ...Backend) LeveledBackend {
 		backend = MultiLogger(backends...)
 	}
 
+	lock.Lock()
 	defaultBackend = AddModuleLevel(backend)
+	lock.Unlock()
 	return defaultBackend
 }
 

--- a/level.go
+++ b/level.go
@@ -26,14 +26,17 @@ const (
 	DEBUG
 )
 
-var levelNames = []string{
-	"CRITICAL",
-	"ERROR",
-	"WARNING",
-	"NOTICE",
-	"INFO",
-	"DEBUG",
-}
+var (
+	lock       sync.Mutex
+	levelNames = []string{
+		"CRITICAL",
+		"ERROR",
+		"WARNING",
+		"NOTICE",
+		"INFO",
+		"DEBUG",
+	}
+)
 
 // String returns the string representation of a logging level.
 func (p Level) String() string {

--- a/logger.go
+++ b/logger.go
@@ -137,7 +137,10 @@ func Reset() {
 
 // IsEnabledFor returns true if the logger is enabled for the given level.
 func (l *Logger) IsEnabledFor(level Level) bool {
-	return defaultBackend.IsEnabledFor(level, l.Module)
+	lock.Lock()
+	enabled := defaultBackend.IsEnabledFor(level, l.Module)
+	defer lock.Unlock()
+	return enabled
 }
 
 func (l *Logger) log(lvl Level, format *string, args ...interface{}) {


### PR DESCRIPTION
If not locked, this results in race:
1. SetBackend(), backend.go:26 - reassigning the global variable (write)
```
func SetBackend(backends ...Backend) LeveledBackend {
	var backend Backend
  // ...

  // DARA RACE START
	defaultBackend = AddModuleLevel(backend)
  // DATA RACE END

	return defaultBackend
}
```

2. IsEnabledFor(), logger.go:141 - accessing a default variable (read)
```
func (l *Logger) IsEnabledFor(level Level) bool {
	return defaultBackend.IsEnabledFor(level, l.Module) // DATA RACE HERE
}
```